### PR TITLE
pyproject.toml: Specify lnst branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ lrc-plotter = "lrc_plotter.lrc_plotter:main"
 python = "^3.9"
 matplotlib = "^3.6.0"
 cycler = "^0.11.0"
-lrc-file = {git = "https://github.com/LNST-project/lrc-file", branch = "main"}
-lnst = {git = "https://github.com/LNST-project/lnst", branch = "master"}
+lrc-file = {git = "https://github.com/LNST-project/lrc-file.git", branch = "main"}
+lnst = {git = "https://github.com/LNST-project/lnst.git", branch = "master"}
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 matplotlib = "^3.6.0"
 cycler = "^0.11.0"
 lrc-file = {git = "https://github.com/LNST-project/lrc-file", branch = "main"}
-lnst = {git = "https://github.com/LNST-project/lnst"}
+lnst = {git = "https://github.com/LNST-project/lnst", branch = "master"}
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
poetry's dependency solving mechanism isn't advanced enough yet to work fully with default branches. Specifying the branch manually should be the best approach as of now.